### PR TITLE
Add generic auto-installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # 2.0.0 / _Not released yet_
 
+New shiny release from new home! `chtf` now supports also non-Homebrew environments, also for auto-install.
+
+Despite major version number bump, `chtf` should work as is for most users of older versions. The only incompatible changes are:
+
+* The user is prompted for confirmation before automatically installing a missing Terraform version. This can be overridden by setting `CHTF_AUTO_INSTALL` to `yes/no/ask`.
+* The variable controlling install location for Terraform versions has been changed from `CASKROOM` to `CHTF_TERRAFORM_DIR`. Homebrew users should not need to touch it, but affects possible Linux users. For non-Homebrew environment the default is `$HOME/.terraforms/`.
+
+All changes:
+
+* Add official support for also other than Homebrew environments ([#1](https://github.com/Yleisradio/chtf/issues/1))
+* Add generic auto-installer using [terraform-installer](https://github.com/robertpeteuil/terraform-installer) ([#2](https://github.com/Yleisradio/chtf/issues/2))
+* Auto-install by default asks confirmation from the user
+* `chtf` extracted from [homebrew-terraforms](https://github.com/Yleisradio/homebrew-terraforms/) to own [chtf](https://github.com/Yleisradio/chtf) project ([Old #53](https://github.com/Yleisradio/homebrew-terraforms/issues/53))
 
 # 1.4.0 / 2018-04-27
 
@@ -10,7 +23,7 @@
 
 # 1.3.0 / 2017-11-06
 
-* Add support for the fish shell [GH-14](https://github.com/Yleisradio/homebrew-terraforms/issues/14)
+* Add support for the fish shell ([Old #14](https://github.com/Yleisradio/homebrew-terraforms/issues/14))
 
 # 1.2.1 / 2016-09-26
 
@@ -19,7 +32,7 @@
 
 # 1.2.0 / 2016-09-26
 
-* Add `CHTF_CURRENT_TERRAFORM_VERSION` variable for easy access to the currently selected version number [GH-3](https://github.com/Yleisradio/homebrew-terraforms/issues/3)
+* Add `CHTF_CURRENT_TERRAFORM_VERSION` variable for easy access to the currently selected version number ([Old #3](https://github.com/Yleisradio/homebrew-terraforms/issues/3))
 
 # 1.1.1 / 2016-06-27
 
@@ -27,7 +40,7 @@
 
 # 1.1.0 / 2016-06-27
 
-* Fix the `CASKROOM` default location [GH-2](https://github.com/Yleisradio/homebrew-terraforms/issues/2)
+* Fix the `CASKROOM` default location ([Old #2](https://github.com/Yleisradio/homebrew-terraforms/issues/2))
 
 # 1.0.1 / 2016-01-22
 
@@ -36,6 +49,5 @@
 # 1.0.0 / 2016-01-22
 
 * First release!
-* Homebrew Casks for Terraform versions from 0.6.6 to 0.6.9
 * `chtf` helper to automate the install and use of a specific Terraform version
 * Homebrew Formula for the `chtf` helper

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ else
 endif
 
 CHTF_FILES := chtf.sh chtf.fish VERSION
+CHTF_BIN_FILES := terraform-install.sh
 
 all:
 
@@ -14,6 +15,9 @@ install:
 	install -d $(DESTDIR)$(PREFIX)/share/chtf
 	for f in $(CHTF_FILES); do \
 	    install -m 0644 chtf/$$f $(DESTDIR)$(PREFIX)/share/chtf; \
+	done
+	for f in $(CHTF_BIN_FILES); do \
+	    install -m 0755 chtf/$$f $(DESTDIR)$(PREFIX)/share/chtf; \
 	done
 
 .PHONY: all install

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Optional automatic instal of missing Terraform versions requires either:
 
 ## Installation
 
+> :warning: **NOTE:** These instructions do not work as is until v2.0.0 is released. See the [Tips section](#tips) for installing the development version.
+
 ### Homebrew
 
 On MacOS (and OSX) the easiest way is to use Homebrew. After installing Homebrew, run:

--- a/README.md
+++ b/README.md
@@ -1,47 +1,203 @@
 # chtf - Terraform version switcher
 
+Do you need different Terraform versions on different projects? Or maybe you want to test your modules with a new Terraform version?
+
 `chtf` is a small shell tool for selecting a specified [Terraform](https://www.terraform.io/) version. It can also install the specified version automatically.
+
+---
+
+## Requirements
+
+`chtf` supports currently [bash](http://www.gnu.org/software/bash/), [zsh](http://zsh.sourceforge.net/), and [fish](https://fishshell.com/) shells. Version switching itself doesn't have any external dependencies.
+
+Optional automatic instal of missing Terraform versions requires either:
+
+- [Homebrew](https://brew.sh/) with [yleisradio/terraforms](https://github.com/Yleisradio/homebrew-terraforms) Tap (see below)
+- bash, unzip, and wget or curl
+
+---
 
 ## Installation
 
-On MacOS (and OSX) the recommended way is to use [Homebrew](https://brew.sh/) and [homebrew-terraforms](https://github.com/Yleisradio/homebrew-terraforms).
-After installing Homebrew, run:
+### Homebrew
 
-    brew tap Yleisradio/terraforms
-    brew install chtf
+On MacOS (and OSX) the easiest way is to use Homebrew. After installing Homebrew, run:
 
-Add the following to the ~/.bashrc or ~/.zshrc file:
+    brew install yleisradio/terraforms/chtf
+
+Homebrew also installs the completion for all supported shells.
+
+### All systems
+
+Manual installation on all systems:
+
+    curl -L -o chtf-2.0.0.tar.gz https://github.com/postmodern/chruby/archive/v2.0.0.tar.gz
+    tar -xzvf chtf-2.0.0.tar.gz
+    cd chtf-2.0.0/
+    make install
+
+The default installation location is `$HOME/local/chtf/`. See the [Tips section](#tips) for installing to other locations.
+
+The `etc/` directory includes completion files for the supported shells. Follow your shell's instructions how to install them.
+
+---
+
+## Configuration
+
+The following environment variables can be used for configuring `chtf`. Click to expand.
+
+<details>
+<summary><strong><code>CHTF_TERRAFORM_DIR</code></strong> - Specifies where the Terraform versions are stored.</summary>
+
+Defaults to the Homebrew Caskroom if the "yleisradio/terraforms" Tap is installed, `$HOME/.terraforms/` otherwise.
+Each version should be installed as `$CHTF_TERRAFORM_DIR/terraform-<version>/terraform`.
+
+</details>
+<details>
+<summary><strong><code>CHTF_AUTO_INSTALL</code></strong> - Controls automatic installation missing Terraform versions.</summary>
+
+Possible values are: `yes`, `no`, and `ask`.
+The default is `ask`, which will prompt the user for confirmation before automatic installation.
+
+</details>
+<details>
+<summary><strong><code>CHTF_AUTO_INSTALL_METHOD</code></strong> - Specifies the method used for automatic installation.</summary>
+
+The default is `homebrew` if `CHTF_TERRAFORM_DIR` is no specified and the "yleisradio/terraforms" Tap is installed, `zip`  otherwise.
+There shouldn't be normally need to set this variable.
+
+</details>
+
+### Activating the `chtf` command
+
+After installing, `chtf` has to be loaded to the shell.
+
+The base directory on the following examples depends how and where `chtf` is installed. This assumes `make install`. With Homebrew, replace `$HOME` with the output of `brew --prefix`.
+
+New shell session has to be started for the changes to take effect.
+
+#### bash and zsh
+
+Add the following to the `~/.bashrc` or `~/.zshrc`:
 
 ```bash
-# Source chtf
-if [[ -f /usr/local/share/chtf/chtf.sh ]]; then
-    source "/usr/local/share/chtf/chtf.sh"
+######################################################################
+# chtf
+
+# Uncomment and change the value to override the default:
+#CHTF_AUTO_INSTALL="ask" # yes/no/ask
+
+if [[ -f "$HOME/share/chtf/chtf.sh" ]]; then
+    source "$HOME/share/chtf/chtf.sh"
 fi
 ```
 
-If you are using fish add the following into ~/.config/fish/config.fish:
+#### fish
+
+Add the following into `~/.config/fish/config.fish`:
 
 ```fish
-# Source chtf
-if test -f /usr/local/share/chtf/chtf.fish
-    source /usr/local/share/chtf/chtf.fish
+######################################################################
+# chtf
+
+# Uncomment and change the value to override the default:
+#set -g CHTF_AUTO_INSTALL ask # yes/no/ask
+
+if test -f $HOME/share/chtf/chtf.fish
+    source $HOME/share/chtf/chtf.fish
 end
 ```
 
-Then select the wanted Terraform version to use with `chtf`.
+## Usage
 
-    chtf 0.11.3
+List all installed Terraform versions:
+
+    chtf
+
+Select the wanted Terraform version, for example:
+
+    chtf 0.13.5
+
+Use the Terraform version installed globally outside `chtf` (e.g. via a package manager):
+
+    chtf system
+
+### Tips
+
+<details>
+<summary><strong>Customized install</strong></summary>
+
+`make install` installs `chtf` by default to the user's `$HOME` directory. But if installed as a root user (e.g. via `sudo`), the default location is `/usr/local` for system wide use. In both cases the wanted location can be specified with `PREFIX`. For example:
+
+    sudo make install PREFIX=/opt
+
+The development version of `chtf` can be used either by `source`ing or `make install`ing from a [clone of this repository](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/cloning-a-repository), or with Homebrew:
+
+    brew install yleisradio/terraforms/chtf --HEAD
+
+</details>
+<details>
+<summary><strong>Automatic switching on new shell session</strong></summary>
+
+If you want to have a default Terraform version selected when starting a new shell session, you can of course add `chtf <version>` to the config file after loading `chtf`.
+A bit more flexible way is to write the wanted version number to a file named `~/.terraform-version`, and read that.
+
+```bash
+# bash and zsh
+if [[ -f "$HOME/.terraform-version" ]]; then
+    chtf "$(< "$HOME/.terraform-version")"
+fi
+```
+
+```fish
+# fish
+if test -f $HOME/.terraform-version
+    chtf (cat $HOME/.terraform-version)
+end
+```
+
+</details>
+<details>
+<summary><strong>Uninstalling Terraform versions</strong></summary>
+
+Homebrew installed Terraform versions can be uninstalled with:
+
+    brew cask uninstall terraform-<version>
+
+Otherwise installed versions can be uninstalled by deleting the directory:
+
+    rm -r "$CHTF_TERRAFORM_DIR/terraform-<version>"
+
+</details>
+<details>
+<summary><strong>Uninstalling chtf</strong></summary>
+
+Homebrew installed `chtf` can be uninstalled with:
+
+    brew uninstall chtf
+
+`chtf` installed with `make` can be uninstalled by deleting the directory:
+
+    rm -r "$HOME/share/chtf" # or where it was installed
+
+</details>
+
+---
 
 ## Contibuting
 
-Bug reports, pull requests, and other contributions are welcome on GitHub at https://github.com/Yleisradio/homebrew-terraforms.
+Bug reports, pull requests, and other contributions are welcome on GitHub at [https://github.com/Yleisradio/chtf](https://github.com/Yleisradio/chtf).
 
 This project is intended to be a safe, welcoming space for collaboration. By participating in this project you agree to abide by the terms of [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 
+---
+
 ## Licence and Credits
 
-The software is available as open source under the terms of the [MIT License](LICENSE).
+The project is released as open source under the terms of the [MIT License](LICENSE).
 
-Original idea and implementation of `chtf` heavily affected by [chruby](https://github.com/postmodern/chruby).
+Original idea and implementation of `chtf` was heavily affected by [chruby](https://github.com/postmodern/chruby).
 
 Included [terraform-installer](https://github.com/robertpeteuil/terraform-installer) is released under the [Apache 2.0 License](https://github.com/robertpeteuil/terraform-installer/blob/1.5.4/LICENSE).
+
+_NOTE: `chtf` was originally part of the [homebrew-terraforms](https://github.com/Yleisradio/homebrew-terraforms/) project, but has been extracted to own project and modified to support also non-Homebrew environments._

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Bug reports, pull requests, and other contributions are welcome on GitHub at htt
 
 This project is intended to be a safe, welcoming space for collaboration. By participating in this project you agree to abide by the terms of [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 
-## Credits
+## Licence and Credits
 
-Idea and implementation heavily affected by [chruby](https://github.com/postmodern/chruby).
+The software is available as open source under the terms of the [MIT License](LICENSE).
+
+Original idea and implementation of `chtf` heavily affected by [chruby](https://github.com/postmodern/chruby).
+
+Included [terraform-installer](https://github.com/robertpeteuil/terraform-installer) is released under the [Apache 2.0 License](https://github.com/robertpeteuil/terraform-installer/blob/1.5.4/LICENSE).

--- a/chtf/chtf.sh
+++ b/chtf/chtf.sh
@@ -110,8 +110,7 @@ _chtf_list() (
             continue
         fi
 
-        local prefix="$(_chtf_list_prefix "$tf_path")"
-        printf '%s %s\n' "$prefix" "$tf_version"
+        printf '%s %s\n' "$(_chtf_list_prefix "$tf_path")" "$tf_version"
     done;
 )
 
@@ -160,6 +159,7 @@ _chtf_confirm() {
         ask)
             printf 'chtf: Do you want to install it? [yN] '
             if [[ -n "$ZSH_NAME" ]]; then
+                # shellcheck disable=SC2162 # ignore zsh command
                 read -k reply
             else
                 read -n 1 -r reply

--- a/chtf/terraform-install.sh
+++ b/chtf/terraform-install.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+
+set -e
+
+# TERRAFORM INSTALLER - Automated Terraform Installation
+#   Apache 2 License - Copyright (c) 2018  Robert Peteuil  @RobertPeteuil
+#
+#     Automatically Download, Extract and Install
+#        Latest or Specific Version of Terraform
+#
+#   from: https://github.com/robertpeteuil/terraform-installer
+
+# Uncomment line below to always use 'sudo' to install to /usr/local/bin/
+# sudoInstall=true
+
+scriptname=$(basename "$0")
+scriptbuildnum="1.5.4"
+scriptbuilddate="2020-06-25"
+
+# CHECK DEPENDANCIES AND SET NET RETRIEVAL TOOL
+if ! unzip -h 2&> /dev/null; then
+  echo "aborting - unzip not installed and required"
+  exit 1
+fi
+
+if curl -h 2&> /dev/null; then
+  nettool="curl"
+elif wget -h 2&> /dev/null; then
+  nettool="wget"
+else
+  echo "aborting - wget or curl not installed and required"
+  exit 1
+fi
+
+if jq --help 2&> /dev/null; then
+  nettool="${nettool}jq"
+fi
+
+displayVer() {
+  echo -e "${scriptname}  ver ${scriptbuildnum} - ${scriptbuilddate}"
+}
+
+usage() {
+  [[ "$1" ]] && echo -e "Download and Install Terraform - Latest Version unless '-i' specified\n"
+  echo -e "usage: ${scriptname} [-i VERSION] [-a] [-c] [-h] [-v]"
+  echo -e "     -i VERSION\t: specify version to install in format '0.11.8' (OPTIONAL)"
+  echo -e "     -a\t\t: automatically use sudo to install to /usr/local/bin"
+  echo -e "     -c\t\t: leave binary in working directory (for CI/DevOps use)"
+  echo -e "     -h\t\t: help"
+  echo -e "     -v\t\t: display ${scriptname} version"
+}
+
+getLatest() {
+  # USE NET RETRIEVAL TOOL TO GET LATEST VERSION
+  case "${nettool}" in
+    # jq installed - parse version from hashicorp website
+    wgetjq)
+      LATEST_ARR=($(wget -q -O- https://releases.hashicorp.com/index.json 2>/dev/null | jq -r '.terraform.versions[].version' | sort -t. -k 1,1nr -k 2,2nr -k 3,3nr))
+      ;;
+    curljq)
+      LATEST_ARR=($(curl -s https://releases.hashicorp.com/index.json 2>/dev/null | jq -r '.terraform.versions[].version' | sort -t. -k 1,1nr -k 2,2nr -k 3,3nr))
+      ;;
+    # parse version from github API
+    wget)
+      LATEST_ARR=($(wget -q -O- https://api.github.com/repos/hashicorp/terraform/releases 2> /dev/null | awk '/tag_name/ {print $2}' | cut -d '"' -f 2 | cut -d 'v' -f 2))
+      ;;
+    curl)
+      LATEST_ARR=($(curl -s https://api.github.com/repos/hashicorp/terraform/releases 2> /dev/null | awk '/tag_name/ {print $2}' | cut -d '"' -f 2 | cut -d 'v' -f 2))
+      ;;
+  esac
+
+# make sure latest version isn't beta or rc
+for ver in "${LATEST_ARR[@]}"; do
+  if [[ ! $ver =~ beta ]] && [[ ! $ver =~ rc ]] && [[ ! $ver =~ alpha ]]; then
+    LATEST="$ver"
+    break
+  fi
+done
+echo -n "$LATEST"
+}
+
+while getopts ":i:achv" arg; do
+  case "${arg}" in
+    a)  sudoInstall=true;;
+    c)  cwdInstall=true;;
+    i)  VERSION=${OPTARG};;
+    h)  usage x; exit;;
+    v)  displayVer; exit;;
+    \?) echo -e "Error - Invalid option: $OPTARG"; usage; exit;;
+    :)  echo "Error - $OPTARG requires an argument"; usage; exit 1;;
+  esac
+done
+shift $((OPTIND-1))
+
+# POPULATE VARIABLES NEEDED TO CREATE DOWNLOAD URL AND FILENAME
+if [[ -z "$VERSION" ]]; then
+  VERSION=$(getLatest)
+fi
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+if [[ "$OS" == "linux" ]]; then
+  PROC=$(lscpu 2> /dev/null | awk '/Architecture/ {if($2 == "x86_64") {print "amd64"; exit} else if($2 ~ /arm/) {print "arm"; exit} else if($2 ~ /aarch64/) {print "arm"; exit} else {print "386"; exit}}')
+  if [[ -z $PROC ]]; then
+    PROC=$(cat /proc/cpuinfo | awk '/model\ name/ {if($0 ~ /ARM/) {print "arm"; exit}}')
+  fi
+  if [[ -z $PROC ]]; then
+    PROC=$(cat /proc/cpuinfo | awk '/flags/ {if($0 ~ /lm/) {print "amd64"; exit} else {print "386"; exit}}')
+  fi
+else
+  PROC="amd64"
+fi
+[[ $PROC =~ arm ]] && PROC="arm"  # terraform downloads use "arm" not full arm type
+
+# CREATE FILENAME AND URL FROM GATHERED PARAMETERS
+FILENAME="terraform_${VERSION}_${OS}_${PROC}.zip"
+LINK="https://releases.hashicorp.com/terraform/${VERSION}/${FILENAME}"
+SHALINK="https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS"
+
+# TEST CALCULATED LINKS
+case "${nettool}" in
+  wget*)
+    LINKVALID=$(wget --spider -S "$LINK" 2>&1 | grep "HTTP/" | awk '{print $2}')
+    SHALINKVALID=$(wget --spider -S "$SHALINK" 2>&1 | grep "HTTP/" | awk '{print $2}')
+    ;;
+  curl*)
+    LINKVALID=$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' "$LINK")
+    SHALINKVALID=$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' "$SHALINK")
+    ;;
+esac
+
+# VERIFY LINK VALIDITY
+if [[ "$LINKVALID" != 200 ]]; then
+  echo -e "Cannot Install - Download URL Invalid"
+  echo -e "\nParameters:"
+  echo -e "\tVER:\t$VERSION"
+  echo -e "\tOS:\t$OS"
+  echo -e "\tPROC:\t$PROC"
+  echo -e "\tURL:\t$LINK"
+  exit 1
+fi
+
+# VERIFY SHA LINK VALIDITY
+if [[ "$SHALINKVALID" != 200 ]]; then
+  echo -e "Cannot Install - URL for Checksum File Invalid"
+  echo -e "\tURL:\t$SHALINK"
+  exit 1
+fi
+
+# DETERMINE DESTINATION
+if [[ "$cwdInstall" ]]; then
+  BINDIR=$(pwd)
+elif [[ -w "/usr/local/bin" ]]; then
+  BINDIR="/usr/local/bin"
+  CMDPREFIX=""
+  STREAMLINED=true
+elif [[ "$sudoInstall" ]]; then
+  BINDIR="/usr/local/bin"
+  CMDPREFIX="sudo "
+  STREAMLINED=true
+else
+  echo -e "Terraform Installer\n"
+  echo "Specify install directory (a,b or c):"
+  echo -en "\t(a) '~/bin'    (b) '/usr/local/bin' as root    (c) abort : "
+  read -r -n 1 SELECTION
+  echo
+  if [ "${SELECTION}" == "a" ] || [ "${SELECTION}" == "A" ]; then
+    BINDIR="${HOME}/bin"
+    CMDPREFIX=""
+  elif [ "${SELECTION}" == "b" ] || [ "${SELECTION}" == "B" ]; then
+    BINDIR="/usr/local/bin"
+    CMDPREFIX="sudo "
+  else
+    exit 0
+  fi
+fi
+
+# CREATE TMPDIR FOR EXTRACTION
+if [[ ! "$cwdInstall" ]]; then
+  TMPDIR=${TMPDIR:-/tmp}
+  UTILTMPDIR="terraform_${VERSION}"
+
+  cd "$TMPDIR" || exit 1
+  mkdir -p "$UTILTMPDIR"
+  cd "$UTILTMPDIR" || exit 1
+fi
+
+# DOWNLOAD ZIP AND CHECKSUM FILES
+case "${nettool}" in
+  wget*)
+    wget -q "$LINK" -O "$FILENAME"
+    wget -q "$SHALINK" -O SHAFILE
+    ;;
+  curl*)
+    curl -s -o "$FILENAME" "$LINK"
+    curl -s -o SHAFILE "$SHALINK"
+    ;;
+esac
+
+# VERIFY ZIP CHECKSUM
+if shasum -h 2&> /dev/null; then
+  expected_sha=$(cat SHAFILE | grep "$FILENAME" | awk '{print $1}')
+  download_sha=$(shasum -a 256 "$FILENAME" | cut -d' ' -f1)
+  if [ $expected_sha != $download_sha ]; then
+    echo "Download Checksum Incorrect"
+    echo "Expected: $expected_sha"
+    echo "Actual: $download_sha"
+    exit 1
+  fi
+fi
+
+# EXTRACT ZIP
+unzip -qq "$FILENAME" || exit 1
+
+# COPY TO DESTINATION
+if [[ ! "$cwdInstall" ]]; then
+  mkdir -p "${BINDIR}" || exit 1
+  ${CMDPREFIX} mv terraform "$BINDIR" || exit 1
+  # CLEANUP AND EXIT
+  cd "${TMPDIR}" || exit 1
+  rm -rf "${UTILTMPDIR}"
+  [[ ! "$STREAMLINED" ]] && echo
+  echo "Terraform Version ${VERSION} installed to ${BINDIR}"
+else
+  echo "Terraform Version ${VERSION} downloaded"
+fi
+
+exit 0

--- a/chtf/terraform-install.sh
+++ b/chtf/terraform-install.sh
@@ -44,7 +44,7 @@ usage() {
   [[ "$1" ]] && echo -e "Download and Install Terraform - Latest Version unless '-i' specified\n"
   echo -e "usage: ${scriptname} [-i VERSION] [-a] [-c] [-h] [-v]"
   echo -e "     -i VERSION\t: specify version to install in format '0.11.8' (OPTIONAL)"
-  echo -e "     -a\t\t: automatically use sudo to install to /usr/local/bin"
+  echo -e "     -a\t\t: automatically use sudo to install to /usr/local/bin (or \$TF_INSTALL_DIR)"
   echo -e "     -c\t\t: leave binary in working directory (for CI/DevOps use)"
   echo -e "     -h\t\t: help"
   echo -e "     -v\t\t: display ${scriptname} version"
@@ -148,6 +148,10 @@ fi
 # DETERMINE DESTINATION
 if [[ "$cwdInstall" ]]; then
   BINDIR=$(pwd)
+elif [[ -n "$TF_INSTALL_DIR" ]]; then
+  BINDIR="$TF_INSTALL_DIR"
+  CMDPREFIX="${sudoInstall:+sudo }"
+  STREAMLINED=true
 elif [[ -w "/usr/local/bin" ]]; then
   BINDIR="/usr/local/bin"
   CMDPREFIX=""
@@ -220,6 +224,7 @@ if [[ ! "$cwdInstall" ]]; then
   [[ ! "$STREAMLINED" ]] && echo
   echo "Terraform Version ${VERSION} installed to ${BINDIR}"
 else
+  rm -f "$FILENAME" SHAFILE
   echo "Terraform Version ${VERSION} downloaded"
 fi
 


### PR DESCRIPTION
Add generic auto-install for also non-Homebrew environments using `terraform-install.sh` from https://github.com/robertpeteuil/terraform-installer which we vendor.

The install method is by default detected automatically, depending if `CHTF_TERRAFORM_DIR` is specified, or if the Homebrew Tap is installed. Everything can of course be forced by the user.

This PR also includes updated documentation and changelog. The install instruction won't completely work though until 2.0 is released and homebrew-terraforms is updated.

**Note**: The PR is still draft waiting for resolution of robertpeteuil/terraform-installer#6. It should be otherwise ready though.