### PR TITLE
Replace `brew tap` call with directory check

### DIFF
--- a/chtf/chtf.fish
+++ b/chtf/chtf.fish
@@ -29,7 +29,8 @@ if not set -q CHTF_TERRAFORM_DIR
     if test "$CHTF_AUTO_INSTALL_METHOD" = homebrew
         set -g CHTF_TERRAFORM_DIR (brew --caskroom)
     else if test -z "$CHTF_AUTO_INSTALL_METHOD"
-        and string match -q 'yleisradio/terraforms' (brew tap 2>/dev/null)
+        and type -q brew
+        and test -d (brew --repo)/Library/Taps/yleisradio/homebrew-terraforms
         # https://github.com/Yleisradio/homebrew-terraforms in use
         set -g CHTF_TERRAFORM_DIR (brew --caskroom)
         set -g CHTF_AUTO_INSTALL_METHOD homebrew

--- a/chtf/chtf.sh
+++ b/chtf/chtf.sh
@@ -28,7 +28,9 @@
 if [[ -z "$CHTF_TERRAFORM_DIR" ]]; then
     if [[ "$CHTF_AUTO_INSTALL_METHOD" == 'homebrew' ]]; then
         CHTF_TERRAFORM_DIR="$(brew --caskroom)"
-    elif [[ -z "$CHTF_AUTO_INSTALL_METHOD" ]] && brew tap 2>/dev/null | grep -q '^yleisradio/terraforms$'; then
+    elif [[ -z "$CHTF_AUTO_INSTALL_METHOD" ]] &&
+        command -v brew >/dev/null &&
+        [[ -d "$(brew --repo)/Library/Taps/yleisradio/homebrew-terraforms" ]]; then
         # https://github.com/Yleisradio/homebrew-terraforms in use
         CHTF_TERRAFORM_DIR="$(brew --caskroom)"
         CHTF_AUTO_INSTALL_METHOD='homebrew'


### PR DESCRIPTION
`brew tap` is really slow (#4), which affects loading time in default Homebrew environments.

A workaround is to declare `CHTF_AUTO_INSTALL_METHOD` before loading, but let's avoid the invocation in all cases. The file hierarchy for Taps can be assumed to be stable enough to check the existence by ourselves.

We still call `brew --caskroom` and `brew --repo`, but they are fast.

Fixes #4.