### PR TITLE
Replace `brew cask install` with `brew install --cask`

### DIFF
--- a/chtf/chtf.fish
+++ b/chtf/chtf.fish
@@ -128,7 +128,7 @@ function _chtf_install -a tf_version
 end
 
 function _chtf_install_homebrew -a tf_version
-    brew cask install "terraform-$tf_version"
+    brew install --cask "terraform-$tf_version"
 end
 
 function _chtf_install_zip -a tf_version

--- a/chtf/chtf.sh
+++ b/chtf/chtf.sh
@@ -145,7 +145,7 @@ _chtf_install() {
 
 _chtf_install_homebrew() {
     local tf_version="$1"
-    brew cask install "terraform-$tf_version"
+    brew install --cask "terraform-$tf_version"
 }
 
 _chtf_install_zip() {


### PR DESCRIPTION
`brew cask install` has been deprecated: https://github.com/Homebrew/brew/pull/9247