### PR TITLE
Fix brew command in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ end
 
 Homebrew installed Terraform versions can be uninstalled with:
 
-    brew cask uninstall terraform-<version>
+    brew uninstall --cask terraform-<version>
 
 Otherwise installed versions can be uninstalled by deleting the directory:
 


### PR DESCRIPTION
`brew cask uninstall` has been replaced with `brew uninstall --cask`.