### PR TITLE
Support "terraforms" Tap from the new GitHub owner, `tmatilai`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.2.3 / _Not released yet_
+## 2.3.0 / 2025-10-20
 
+* Support "terraforms" Tap from the new GitHub owner, `tmatilai` ([#20](https://github.com/tmatilai/chtf/issues/20))
 
 ## 2.2.2 / 2024-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,25 @@
 
 ## 2.2.2 / 2024-03-17
 
-* Remove extra path printing in the fish version ([#18](https://github.com/Yleisradio/chtf/issues/18))
+* Remove extra path printing in the fish version ([#18](https://github.com/tmatilai/chtf/issues/18))
 
 ## 2.2.1 / 2024-03-17
 
-* Fix installation of new Terraform version in the fish version ([#17](https://github.com/Yleisradio/chtf/issues/17))
+* Fix installation of new Terraform version in the fish version ([#17](https://github.com/tmatilai/chtf/issues/17))
 
 ## 2.2.0 / 2024-03-17
 
-* Support having dashes in Cask names ([#16](https://github.com/Yleisradio/chtf/issues/16), [homebrew-terraforms#217](https://github.com/Yleisradio/homebrew-terraforms/issues/217))
-* Fix uninstall command and typos in the README ([#10](https://github.com/Yleisradio/chtf/issues/10), [#15](https://github.com/Yleisradio/chtf/issues/15))
+* Support having dashes in Cask names ([#16](https://github.com/tmatilai/chtf/issues/16), [homebrew-terraforms#217](https://github.com/tmatilai/homebrew-terraforms/issues/217))
+* Fix uninstall command and typos in the README ([#10](https://github.com/tmatilai/chtf/issues/10), [#15](https://github.com/tmatilai/chtf/issues/15))
 
 ## 2.1.1 / 2020-12-18
 
-* Replace `brew cask install` with `brew install --cask` ([#8](https://github.com/Yleisradio/chtf/issues/8))
+* Replace `brew cask install` with `brew install --cask` ([#8](https://github.com/tmatilai/chtf/issues/8))
 
 ## 2.1.0 / 2020-12-06
 
-* Reduce initial loading time significantly on Homebrew environments ([#4](https://github.com/Yleisradio/chtf/issues/4), [#5](https://github.com/Yleisradio/chtf/issues/5))
-* Install Fish function and completion for autoloading ([#6](https://github.com/Yleisradio/chtf/issues/6))
+* Reduce initial loading time significantly on Homebrew environments ([#4](https://github.com/tmatilai/chtf/issues/4), [#5](https://github.com/tmatilai/chtf/issues/5))
+* Install Fish function and completion for autoloading ([#6](https://github.com/tmatilai/chtf/issues/6))
 
 ## 2.0.0 / 2020-11-05
 
@@ -35,10 +35,10 @@ Despite major version number bump, `chtf` should work as is for most users of ol
 
 All changes:
 
-* Add official support for also other than Homebrew environments ([#1](https://github.com/Yleisradio/chtf/issues/1))
-* Add generic auto-installer using [terraform-installer](https://github.com/robertpeteuil/terraform-installer) ([#2](https://github.com/Yleisradio/chtf/issues/2))
+* Add official support for also other than Homebrew environments ([#1](https://github.com/tmatilai/chtf/issues/1))
+* Add generic auto-installer using [terraform-installer](https://github.com/robertpeteuil/terraform-installer) ([#2](https://github.com/tmatilai/chtf/issues/2))
 * Auto-install by default asks confirmation from the user
-* `chtf` extracted from [homebrew-terraforms](https://github.com/Yleisradio/homebrew-terraforms/) to own [chtf](https://github.com/Yleisradio/chtf) project ([Old #53](https://github.com/Yleisradio/homebrew-terraforms/issues/53))
+* `chtf` extracted from [homebrew-terraforms](https://github.com/tmatilai/homebrew-terraforms/) to own [chtf](https://github.com/tmatilai/chtf) project ([Old #53](https://github.com/tmatilai/homebrew-terraforms/issues/53))
 
 ## 1.4.0 / 2018-04-27
 
@@ -49,7 +49,7 @@ All changes:
 
 ## 1.3.0 / 2017-11-06
 
-* Add support for the fish shell ([Old #14](https://github.com/Yleisradio/homebrew-terraforms/issues/14))
+* Add support for the fish shell ([Old #14](https://github.com/tmatilai/homebrew-terraforms/issues/14))
 
 ## 1.2.1 / 2016-09-26
 
@@ -58,7 +58,7 @@ All changes:
 
 ## 1.2.0 / 2016-09-26
 
-* Add `CHTF_CURRENT_TERRAFORM_VERSION` variable for easy access to the currently selected version number ([Old #3](https://github.com/Yleisradio/homebrew-terraforms/issues/3))
+* Add `CHTF_CURRENT_TERRAFORM_VERSION` variable for easy access to the currently selected version number ([Old #3](https://github.com/tmatilai/homebrew-terraforms/issues/3))
 
 ## 1.1.1 / 2016-06-27
 
@@ -66,7 +66,7 @@ All changes:
 
 ## 1.1.0 / 2016-06-27
 
-* Fix the `CASKROOM` default location ([Old #2](https://github.com/Yleisradio/homebrew-terraforms/issues/2))
+* Fix the `CASKROOM` default location ([Old #2](https://github.com/tmatilai/homebrew-terraforms/issues/2))
 
 ## 1.0.1 / 2016-01-22
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016-2020 Yleisradio Oy
-Copyright (c) 2020, 2024 Teemu Matilainen
+Copyright (c) 2020, 2024-2025 Teemu Matilainen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Do you need different Terraform versions on different projects? Or maybe you wan
 
 Optional automatic install of missing Terraform versions requires either:
 
-- [Homebrew](https://brew.sh/) with [yleisradio/terraforms](https://github.com/Yleisradio/homebrew-terraforms) Tap (see below)
+- [Homebrew](https://brew.sh/) with [tmatilai/terraforms](https://github.com/tmatilai/homebrew-terraforms) Tap (see below)
 - bash, unzip, and wget or curl
 
 ---
@@ -23,7 +23,7 @@ Optional automatic install of missing Terraform versions requires either:
 
 On MacOS (and OSX) the easiest way is to use Homebrew. After installing Homebrew, run:
 
-    brew install yleisradio/terraforms/chtf
+    brew install tmatilai/terraforms/chtf
 
 Homebrew also installs the completion for all supported shells.
 
@@ -31,9 +31,9 @@ Homebrew also installs the completion for all supported shells.
 
 Manual installation on all systems:
 
-    curl -L -o chtf-2.2.2.tar.gz https://github.com/Yleisradio/chtf/archive/v2.2.2.tar.gz
-    tar -xzvf chtf-2.2.2.tar.gz
-    cd chtf-2.2.2/
+    curl -L -o chtf-2.3.0.tar.gz https://github.com/tmatilai/chtf/archive/v2.3.0.tar.gz
+    tar -xzvf chtf-2.3.0.tar.gz
+    cd chtf-2.3.0/
     make install
 
 The default installation location is `$HOME/share/chtf/` for bash/zsh, and `$HOME/.config/fish/` for fish. See the [Tips section](#tips) for installing to other locations.
@@ -49,7 +49,7 @@ The following environment variables can be used for configuring `chtf`. Click to
 <details>
 <summary><strong><code>CHTF_TERRAFORM_DIR</code></strong> - Specifies where the Terraform versions are stored.</summary>
 
-Defaults to the Homebrew Caskroom if the "yleisradio/terraforms" Tap is installed, `$HOME/.terraforms/` otherwise.
+Defaults to the Homebrew Caskroom if the "tmatilai/terraforms" Tap is installed, `$HOME/.terraforms/` otherwise.
 Each version should be installed as `$CHTF_TERRAFORM_DIR/terraform-<version>/terraform`.
 
 </details>
@@ -63,7 +63,7 @@ The default is `ask`, which will prompt the user for confirmation before automat
 <details>
 <summary><strong><code>CHTF_AUTO_INSTALL_METHOD</code></strong> - Specifies the method used for automatic installation.</summary>
 
-The default is `homebrew` if `CHTF_TERRAFORM_DIR` is no specified and the "yleisradio/terraforms" Tap is installed, `zip`  otherwise.
+The default is `homebrew` if `CHTF_TERRAFORM_DIR` is no specified and the "tmatilai/terraforms" Tap is installed, `zip`  otherwise.
 There shouldn't be normally need to set this variable.
 
 </details>
@@ -121,7 +121,7 @@ Use the Terraform version installed globally outside `chtf` (e.g. via a package 
 
 The development version of `chtf` can be used either by `source`ing or `make install`ing from a [clone of this repository](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/cloning-a-repository), or with Homebrew:
 
-    brew install yleisradio/terraforms/chtf --HEAD
+    brew install tmatilai/terraforms/chtf --HEAD
 
 </details>
 <details>
@@ -176,7 +176,7 @@ Homebrew installed `chtf` can be uninstalled with:
 
 ## Contributing
 
-Bug reports, pull requests, and other contributions are welcome on GitHub at [https://github.com/Yleisradio/chtf](https://github.com/Yleisradio/chtf).
+Bug reports, pull requests, and other contributions are welcome on GitHub at [https://github.com/tmatilai/chtf](https://github.com/tmatilai/chtf).
 
 This project is intended to be a safe, welcoming space for collaboration. By participating in this project you agree to abide by the terms of [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 
@@ -190,4 +190,4 @@ Original idea and implementation of `chtf` was heavily affected by [chruby](http
 
 Included [terraform-installer](https://github.com/robertpeteuil/terraform-installer) is released under the [Apache 2.0 License](https://github.com/robertpeteuil/terraform-installer/blob/1.5.4/LICENSE).
 
-_NOTE: `chtf` was originally part of the [homebrew-terraforms](https://github.com/Yleisradio/homebrew-terraforms/) project, but has been extracted to own project and modified to support also non-Homebrew environments._
+_NOTE: `chtf` was originally part of the [homebrew-terraforms](https://github.com/tmatilai/homebrew-terraforms/) project, but has been extracted to own project and modified to support also non-Homebrew environments._

--- a/chtf/chtf.fish
+++ b/chtf/chtf.fish
@@ -1,6 +1,6 @@
 # Copyright (c) 2017 Alex Kulbii
 # Copyright (c) 2018 Yleisradio Oy
-# Copyright (c) 2020, 2024 Teemu Matilainen
+# Copyright (c) 2020, 2024-2025 Teemu Matilainen
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,7 +21,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-set -g CHTF_VERSION 2.2.3-dev
+set -g CHTF_VERSION 2.3.0
 
 # Set defaults
 
@@ -32,8 +32,11 @@ if not set -q CHTF_TERRAFORM_DIR
         set -g CHTF_TERRAFORM_DIR (brew --caskroom)
     else if test -z "$CHTF_AUTO_INSTALL_METHOD"
         and type -q brew
-        and test -d (brew --repo)/Library/Taps/yleisradio/homebrew-terraforms
-        # https://github.com/Yleisradio/homebrew-terraforms in use
+        and begin
+            test -d (brew --repo)/Library/Taps/tmatilai/homebrew-terraforms
+            or test -d (brew --repo)/Library/Taps/yleisradio/homebrew-terraforms
+        end
+        # https://github.com/tmatilai/homebrew-terraforms in use
         set -g CHTF_TERRAFORM_DIR (brew --caskroom)
         set -g CHTF_AUTO_INSTALL_METHOD homebrew
     else

--- a/chtf/chtf.sh
+++ b/chtf/chtf.sh
@@ -1,6 +1,6 @@
 # Copyright (c) 2012-2016 Hal Brodigan
 # Copyright (c) 2016-2018 Yleisradio Oy
-# Copyright (c) 2020, 2024 Teemu Matilainen
+# Copyright (c) 2020, 2024-2025 Teemu Matilainen
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -21,7 +21,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-CHTF_VERSION='2.2.3-dev'
+CHTF_VERSION='2.3.0'
 
 # Set defaults
 
@@ -32,8 +32,8 @@ if [[ -z "$CHTF_TERRAFORM_DIR" ]]; then
         CHTF_TERRAFORM_DIR="$(brew --caskroom)"
     elif [[ -z "$CHTF_AUTO_INSTALL_METHOD" ]] &&
         command -v brew >/dev/null &&
-        [[ -d "$(brew --repo)/Library/Taps/yleisradio/homebrew-terraforms" ]]; then
-        # https://github.com/Yleisradio/homebrew-terraforms in use
+        [[ -d "$(brew --repo)/Library/Taps/tmatilai/homebrew-terraforms" || -d "$(brew --repo)/Library/Taps/yleisradio/homebrew-terraforms" ]]; then
+        # https://github.com/tmatilai/homebrew-terraforms in use
         CHTF_TERRAFORM_DIR="$(brew --caskroom)"
         CHTF_AUTO_INSTALL_METHOD='homebrew'
     else


### PR DESCRIPTION
Both the `chtf` and `homebrew-terraforms` repositories have been moved to a new GitHub owner, `tmatilai`. Update all references, and add support for installing the Homebrew Tap from either the new or old owner.

Release as version 2.3.0.