### PR TITLE
Migrate away from the yleisradio Tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.1 / _Not released yet_
 
+* Automatically migrate from the old `yleisradio/terraforms` tap to `tmatilai/terraforms` on auto-install
 
 ## 2.3.0 / 2025-10-20
 

--- a/chtf/chtf.fish
+++ b/chtf/chtf.fish
@@ -30,6 +30,7 @@ set -q CHTF_AUTO_INSTALL; or set -g CHTF_AUTO_INSTALL ask
 if not set -q CHTF_TERRAFORM_DIR
     if test "$CHTF_AUTO_INSTALL_METHOD" = homebrew
         set -g CHTF_TERRAFORM_DIR (brew --caskroom)
+    # TODO: Drop the legacy yleisradio tap detection in 3.0 (along with the migration in _chtf_install_homebrew)
     else if test -z "$CHTF_AUTO_INSTALL_METHOD"
         and type -q brew
         and begin
@@ -157,6 +158,15 @@ end
 
 function _chtf_install_homebrew -a tf_version
     set -l tf_cask_version (_chtf_cask_version $tf_version)
+    # Migrate from the old yleisradio tap owner to tmatilai if needed
+    # TODO: Remove this migration in 3.0
+    if test -d (brew --repo)/Library/Taps/yleisradio/homebrew-terraforms
+        echo 'chtf: Migrating from yleisradio/terraforms tap to tmatilai/terraforms'
+        brew untap yleisradio/terraforms
+    end
+    if not test -d (brew --repo)/Library/Taps/tmatilai/homebrew-terraforms
+        brew tap tmatilai/terraforms
+    end
     brew install --cask "terraform-$tf_cask_version"
 end
 

--- a/chtf/chtf.sh
+++ b/chtf/chtf.sh
@@ -30,6 +30,7 @@ CHTF_VERSION='2.3.1-dev'
 if [[ -z "$CHTF_TERRAFORM_DIR" ]]; then
     if [[ "$CHTF_AUTO_INSTALL_METHOD" == 'homebrew' ]]; then
         CHTF_TERRAFORM_DIR="$(brew --caskroom)"
+    # TODO: Drop the legacy yleisradio tap detection in 3.0 (along with the migration in _chtf_install_homebrew)
     elif [[ -z "$CHTF_AUTO_INSTALL_METHOD" ]] &&
         command -v brew >/dev/null &&
         [[ -d "$(brew --repo)/Library/Taps/tmatilai/homebrew-terraforms" || -d "$(brew --repo)/Library/Taps/yleisradio/homebrew-terraforms" ]]; then
@@ -172,6 +173,15 @@ _chtf_install() {
 
 _chtf_install_homebrew() {
     local tf_cask_version="$(_chtf_cask_version "$1")"
+    # Migrate from the old yleisradio tap owner to tmatilai if needed
+    # TODO: Remove this migration in 3.0
+    if [[ -d "$(brew --repo)/Library/Taps/yleisradio/homebrew-terraforms" ]]; then
+        echo 'chtf: Migrating from yleisradio/terraforms tap to tmatilai/terraforms'
+        brew untap yleisradio/terraforms
+    fi
+    if [[ ! -d "$(brew --repo)/Library/Taps/tmatilai/homebrew-terraforms" ]]; then
+        brew tap tmatilai/terraforms
+    fi
     brew install --cask "terraform-$tf_cask_version"
 }
 


### PR DESCRIPTION
The yleisradio/terraforms Tap has moved to tmatilai/terraforms, so automatically untap the old one and tap the new one on auto-install.