### PR TITLE
Trust the tmatilai/terraforms Tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.1 / _Not released yet_
 
 * Automatically migrate from the old `yleisradio/terraforms` tap to `tmatilai/terraforms` on auto-install
+* Trust the `tmatilai/terraforms` Homebrew Tap before auto-installing Terraform versions ([Homebrew Tap Trust](https://docs.brew.sh/Tap-Trust))
 
 ## 2.3.0 / 2025-10-20
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Optional automatic install of missing Terraform versions requires either:
 
 On MacOS (and OSX) the easiest way is to use Homebrew. After installing Homebrew, run:
 
+    brew trust tmatilai/terraforms
     brew install tmatilai/terraforms/chtf
 
 Homebrew also installs the completion for all supported shells.

--- a/chtf/chtf.fish
+++ b/chtf/chtf.fish
@@ -167,6 +167,7 @@ function _chtf_install_homebrew -a tf_version
     if not test -d (brew --repo)/Library/Taps/tmatilai/homebrew-terraforms
         brew tap tmatilai/terraforms
     end
+    brew trust tmatilai/terraforms
     brew install --cask "terraform-$tf_cask_version"
 end
 

--- a/chtf/chtf.sh
+++ b/chtf/chtf.sh
@@ -182,6 +182,7 @@ _chtf_install_homebrew() {
     if [[ ! -d "$(brew --repo)/Library/Taps/tmatilai/homebrew-terraforms" ]]; then
         brew tap tmatilai/terraforms
     fi
+    brew trust tmatilai/terraforms
     brew install --cask "terraform-$tf_cask_version"
 }
 


### PR DESCRIPTION
Recent Homebrew can require non-official Taps to be trusted before use (https://docs.brew.sh/Tap-Trust), so trust the Tap on auto-install and document it for manual installs too.